### PR TITLE
[cherry-pick] improve performance when handling unused variables in `collapse_vars` (#3084)

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1476,8 +1476,9 @@ merge(Compressor.prototype, {
                 if (expr instanceof AST_VarDef && expr.name instanceof AST_SymbolDeclaration) {
                     var def = expr.name.definition();
                     if (!member(expr.name, def.orig)) return;
-                    var declared = def.orig.length - def.eliminated;
                     var referenced = def.references.length - def.replaced;
+                    if (!referenced) return;
+                    var declared = def.orig.length - def.eliminated;
                     if (declared > 1 && !(expr.name instanceof AST_SymbolFunarg)
                         || (referenced > 1 ? mangleable_var(expr) : !compressor.exposed(def))) {
                         return make_node(AST_SymbolRef, expr.name, expr.name);


### PR DESCRIPTION
fixes #3082