### PR TITLE
Merge upstream bug fixes to pass uglify-js v3.3.24 `expect_stdout` tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,10 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 
 - `dead_code` (default: `true`) -- remove unreachable code
 
+- `defaults` (default: `true`) -- Pass `false` to disable most default
+  enabled `compress` transforms. Useful when you only want to enable a few
+  `compress` options while disabling the rest.
+
 - `drop_console` (default: `false`) -- Pass `true` to discard calls to
   `console.*` functions. If you wish to drop a specific function call
   such as `console.info` and/or retain side effects from function arguments

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -617,6 +617,10 @@ merge(Compressor.prototype, {
             tw.in_loop = this;
             push(tw);
             this.body.walk(tw);
+            if (has_break_or_continue(this)) {
+                pop(tw);
+                push(tw);
+            }
             this.condition.walk(tw);
             pop(tw);
             tw.in_loop = saved_loop;
@@ -627,19 +631,17 @@ merge(Compressor.prototype, {
             if (this.init) this.init.walk(tw);
             var saved_loop = tw.in_loop;
             tw.in_loop = this;
-            if (this.condition) {
-                push(tw);
-                this.condition.walk(tw);
-                pop(tw);
-            }
             push(tw);
+            if (this.condition) this.condition.walk(tw);
             this.body.walk(tw);
-            pop(tw);
             if (this.step) {
-                push(tw);
+                if (has_break_or_continue(this)) {
+                    pop(tw);
+                    push(tw);
+                }
                 this.step.walk(tw);
-                pop(tw);
             }
+            pop(tw);
             tw.in_loop = saved_loop;
             return true;
         });
@@ -813,8 +815,7 @@ merge(Compressor.prototype, {
             var saved_loop = tw.in_loop;
             tw.in_loop = this;
             push(tw);
-            this.condition.walk(tw);
-            this.body.walk(tw);
+            descend();
             pop(tw);
             tw.in_loop = saved_loop;
             return true;
@@ -3991,6 +3992,20 @@ merge(Compressor.prototype, {
         return compressor.option("loops") ? make_node(AST_For, self, self).optimize(compressor) : self;
     });
 
+    function has_break_or_continue(loop, parent) {
+        var found = false;
+        var tw = new TreeWalker(function(node) {
+            if (found || node instanceof AST_Scope) return true;
+            if (node instanceof AST_LoopControl && tw.loopcontrol_target(node) === loop) {
+                return found = true;
+            }
+        });
+        if (parent instanceof AST_LabeledStatement) tw.push(parent);
+        tw.push(loop);
+        loop.body.walk(tw);
+        return found;
+    }
+
     OPT(AST_Do, function(self, compressor){
         if (!compressor.option("loops")) return self;
         var cond = self.condition.tail_node().evaluate(compressor);
@@ -4005,22 +4020,16 @@ merge(Compressor.prototype, {
                     ]
                 })
             }).optimize(compressor);
-            var has_loop_control = false;
-            var tw = new TreeWalker(function(node) {
-                if (node instanceof AST_Scope || has_loop_control) return true;
-                if (node instanceof AST_LoopControl && tw.loopcontrol_target(node) === self)
-                    return has_loop_control = true;
-            });
-            var parent = compressor.parent();
-            (parent instanceof AST_LabeledStatement ? parent : self).walk(tw);
-            if (!has_loop_control) return make_node(AST_BlockStatement, self.body, {
-                body: [
-                    self.body,
-                    make_node(AST_SimpleStatement, self.condition, {
-                        body: self.condition
-                    })
-                ]
-            }).optimize(compressor);
+            if (!has_break_or_continue(self, compressor.parent())) {
+                return make_node(AST_BlockStatement, self.body, {
+                    body: [
+                        self.body,
+                        make_node(AST_SimpleStatement, self.condition, {
+                            body: self.condition
+                        })
+                    ]
+                }).optimize(compressor);
+            }
         }
         return self;
     });

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -4789,7 +4789,8 @@ merge(Compressor.prototype, {
             stat = stat[0];
         }
         var is_regular_func = is_func && !fn.is_generator && !fn.async;
-        if (compressor.option("inline") && stat instanceof AST_Return && is_regular_func) {
+        var can_inline = compressor.option("inline") && !self.is_expr_pure(compressor);
+        if (can_inline && stat instanceof AST_Return && is_regular_func) {
             var value = stat.value;
             if (!value || value.is_constant_expression()) {
                 var args = self.args.concat(value || make_node(AST_Undefined, self));
@@ -4798,7 +4799,7 @@ merge(Compressor.prototype, {
         }
         if (is_regular_func) {
             var def, value, scope, in_loop, level = -1;
-            if (compressor.option("inline")
+            if (can_inline
                 && simple_args
                 && !fn.uses_arguments
                 && !fn.uses_eval
@@ -5689,11 +5690,12 @@ merge(Compressor.prototype, {
                 return make_node(AST_Infinity, self).optimize(compressor);
             }
         }
-        if (compressor.option("reduce_vars")
-            && is_lhs(self, compressor.parent()) !== self) {
+        var parent = compressor.parent();
+        if (compressor.option("reduce_vars") && is_lhs(self, parent) !== self) {
             var d = self.definition();
             var fixed = self.fixed_value();
-            var single_use = d.single_use;
+            var single_use = d.single_use
+                && !(parent instanceof AST_Call && parent.is_expr_pure(compressor));
             if (single_use && (fixed instanceof AST_Lambda || fixed instanceof AST_Class)) {
                 if (d.scope !== self.scope
                     && (!compressor.option("reduce_funcs") && fixed instanceof AST_Lambda

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -3248,6 +3248,17 @@ merge(Compressor.prototype, {
         return self;
     });
 
+    function opt_AST_Lambda(self, compressor) {
+        tighten_body(self.body, compressor);
+        if (compressor.option("side_effects")
+            && self.body.length == 1
+            && self.body[0] === compressor.has_directive("use strict")) {
+            self.body.length = 0;
+        }
+        return self;
+    }
+    OPT(AST_Lambda, opt_AST_Lambda);
+
     AST_Scope.DEFMETHOD("drop_unused", function(compressor){
         if (!compressor.option("unused")) return;
         if (compressor.has_directive("use asm")) return;
@@ -6445,7 +6456,9 @@ merge(Compressor.prototype, {
     });
 
     OPT(AST_Arrow, function(self, compressor){
-        if (!(self.body instanceof AST_Node)) tighten_body(self.body, compressor);
+        if (!(self.body instanceof AST_Node)) {
+            self = opt_AST_Lambda(self, compressor);
+        }
         if (compressor.option("arrows")
             && self.body.length == 1
             && self.body[0] instanceof AST_Return) {
@@ -6456,7 +6469,7 @@ merge(Compressor.prototype, {
     });
 
     OPT(AST_Function, function(self, compressor){
-        tighten_body(self.body, compressor);
+        self = opt_AST_Lambda(self, compressor);
         if (compressor.option("unsafe_arrows")
             && compressor.option("ecma") >= 6
             && !self.name

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -47,6 +47,7 @@ function Compressor(options, false_by_default) {
     if (!(this instanceof Compressor))
         return new Compressor(options, false_by_default);
     TreeTransformer.call(this, this.before, this.after);
+    if (options.defaults !== undefined && !options.defaults) false_by_default = true;
     this.options = defaults(options, {
         arguments     : !false_by_default,
         arrows        : !false_by_default,
@@ -56,6 +57,7 @@ function Compressor(options, false_by_default) {
         computed_props: !false_by_default,
         conditionals  : !false_by_default,
         dead_code     : !false_by_default,
+        defaults      : true,
         drop_console  : false,
         drop_debugger : !false_by_default,
         ecma          : 5,

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -1026,8 +1026,9 @@ merge(Compressor.prototype, {
     }
 
     function tighten_body(statements, compressor) {
+        var in_loop, in_try;
         var scope = compressor.find_parent(AST_Scope).get_defun_scope();
-        var in_loop = is_in_loop();
+        find_loop_scope_try();
         var CHANGED, max_iter = 10;
         do {
             CHANGED = false;
@@ -1050,12 +1051,20 @@ merge(Compressor.prototype, {
             }
         } while (CHANGED && max_iter-- > 0);
 
-        function is_in_loop() {
-            for (var node, level = 0; node = compressor.parent(level); level++) {
-                if (node instanceof AST_IterationStatement) return true;
-                if (node instanceof AST_Scope) break;
-            }
-            return false;
+        function find_loop_scope_try() {
+            var node = compressor.self(), level = 0;
+            do {
+                if (node instanceof AST_Catch || node instanceof AST_Finally) {
+                    level++;
+                } else if (node instanceof AST_IterationStatement) {
+                    in_loop = true;
+                } else if (node instanceof AST_Scope) {
+                    scope = node;
+                    break;
+                } else if (node instanceof AST_Try) {
+                    in_try = true;
+                }
+            } while (node = compressor.parent(level++));
         }
 
         // Search from right to left for assignment-like expressions:
@@ -1070,7 +1079,6 @@ merge(Compressor.prototype, {
             if (scope.uses_eval || scope.uses_with) return statements;
             var args;
             var candidates = [];
-            var in_try = compressor.self() instanceof AST_Try;
             var stat_index = statements.length;
             var scanner = new TreeTransformer(function(node, descend) {
                 if (abort) return node;
@@ -1582,7 +1590,10 @@ merge(Compressor.prototype, {
                 if (def.orig.length == 1 && def.orig[0] instanceof AST_SymbolDefun) return false;
                 if (def.scope.get_defun_scope() !== scope) return true;
                 return !all(def.references, function(ref) {
-                    return ref.scope.get_defun_scope() === scope;
+                    var s = ref.scope.get_defun_scope();
+                    // "block" scope within AST_Catch
+                    if (s.TYPE == "Scope") s = s.parent_scope;
+                    return s === scope;
                 });
             }
 

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -566,6 +566,15 @@ merge(Compressor.prototype, {
         def(AST_Block, function(tw, descend, compressor) {
             reset_block_variables(compressor, this);
         });
+        def(AST_Case, function(tw) {
+            push(tw);
+            this.expression.walk(tw);
+            pop(tw);
+            push(tw);
+            walk_body(this, tw);
+            pop(tw);
+            return true;
+        });
         def(AST_ClassExpression, function(tw, descend) {
             this.inlined = false;
             push(tw);
@@ -580,6 +589,12 @@ merge(Compressor.prototype, {
             pop(tw);
             push(tw);
             this.alternative.walk(tw);
+            pop(tw);
+            return true;
+        });
+        def(AST_Default, function(tw, descend) {
+            push(tw);
+            descend();
             pop(tw);
             return true;
         });
@@ -688,12 +703,6 @@ merge(Compressor.prototype, {
         def(AST_LabeledStatement, function(tw) {
             push(tw);
             this.body.walk(tw);
-            pop(tw);
-            return true;
-        });
-        def(AST_SwitchBranch, function(tw, descend) {
-            push(tw);
-            descend();
             pop(tw);
             return true;
         });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -93,7 +93,12 @@ TreeTransformer.prototype = new TreeWalker;
         self.body = do_list(self.body, tw);
     });
 
-    _(AST_DWLoop, function(self, tw){
+    _(AST_Do, function(self, tw){
+        self.body = self.body.transform(tw);
+        self.condition = self.condition.transform(tw);
+    });
+
+    _(AST_While, function(self, tw){
         self.condition = self.condition.transform(tw);
         self.body = self.body.transform(tw);
     });

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -2303,8 +2303,8 @@ unused_orig: {
             var a;
             var c = b;
             for (var d in c) {
-                var a = c[0];
-                return --b + a;
+                var a;
+                return --b + c[0];
             }
             try {
             } catch (e) {
@@ -4964,4 +4964,109 @@ issue_2931: {
         }());
     }
     expect_stdout: "undefined"
+}
+
+issue_2954_1: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var a = "PASS", b;
+        try {
+            do {
+                b = function() {
+                    throw 0;
+                }();
+                a = "FAIL";
+                b && b.c;
+            } while (0);
+        } catch (e) {
+        }
+        console.log(a);
+    }
+    expect: {
+        var a = "PASS", b;
+        try {
+            do {
+                b = function() {
+                    throw 0;
+                }();
+                a = "FAIL";
+                b && b.c;
+            } while (0);
+        } catch (e) {
+        }
+        console.log(a);
+    }
+    expect_stdout: "PASS"
+}
+
+issue_2954_2: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var a = "FAIL_1", b;
+        try {
+            throw 0;
+        } catch (e) {
+            do {
+                b = function() {
+                    throw new Error("PASS");
+                }();
+                a = "FAIL_2";
+                b && b.c;
+            } while (0);
+        }
+        console.log(a);
+    }
+    expect: {
+        var a = "FAIL_1", b;
+        try {
+            throw 0;
+        } catch (e) {
+            do {
+                a = "FAIL_2";
+                (b = function() {
+                    throw new Error("PASS");
+                }()) && b.c;
+            } while (0);
+        }
+        console.log(a);
+    }
+    expect_stdout: Error("PASS")
+}
+
+issue_2954_3: {
+    options = {
+        collapse_vars: true,
+    }
+    input: {
+        var a = "FAIL_1", b;
+        try {
+        } finally {
+            do {
+                b = function() {
+                    throw new Error("PASS");
+                }();
+                a = "FAIL_2";
+                b && b.c;
+            } while (0);
+        }
+        console.log(a);
+    }
+    expect: {
+        var a = "FAIL_1", b;
+        try {
+        } finally {
+            do {
+                a = "FAIL_2";
+                (b = function() {
+                    throw new Error("PASS");
+                }()) && b.c;
+            } while (0);
+        }
+        console.log(a);
+    }
+    expect_stdout: Error("PASS")
 }

--- a/test/compress/defaults.js
+++ b/test/compress/defaults.js
@@ -1,0 +1,96 @@
+defaults_undefined: {
+    options = {
+        defaults: undefined,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        if (true)
+            console.log(1 + 2);
+    }
+    expect_stdout: "3"
+}
+
+defaults_false: {
+    options = {
+        defaults: false,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        if (true)
+            console.log(1 + 2);
+    }
+    expect_stdout: "3"
+}
+
+defaults_false_evaluate_true: {
+    options = {
+        defaults: false,
+        evaluate: true,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        if (true)
+            console.log(3);
+    }
+    expect_stdout: "3"
+}
+
+defaults_true: {
+    options = {
+        defaults: true,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        console.log(3);
+    }
+    expect_stdout: "3"
+}
+
+defaults_true_conditionals_false: {
+    options = {
+        defaults: true,
+        conditionals: false,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        if (1)
+            console.log(3);
+    }
+    expect_stdout: "3"
+}
+
+defaults_true_evaluate_false: {
+    options = {
+        defaults: true,
+        evaluate: false,
+    }
+    input: {
+        if (true) {
+            console.log(1 + 2);
+        }
+    }
+    expect: {
+        1 && console.log(1 + 2);
+    }
+    expect_stdout: "3"
+}

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -2447,3 +2447,93 @@ issue_3125: {
     }
     expect_stdout: "PASS"
 }
+
+drop_lone_use_strict: {
+    options = {
+        side_effects: true,
+    }
+    input: {
+        function f1() {
+            "use strict";
+        }
+        function f2() {
+            "use strict";
+            function f3() {
+                "use strict";
+            }
+        }
+        (function f4() {
+            "use strict";
+        })();
+    }
+    expect: {
+        function f1() {
+        }
+        function f2() {
+            "use strict";
+            function f3() {
+            }
+        }
+    }
+}
+
+drop_lone_use_strict_arrows_1: {
+    options = {
+        side_effects: true,
+    }
+    input: {
+        var f0 = () => 0;
+        var f1 = () => {
+            "use strict";
+        }
+        var f2 = () => {
+            "use strict";
+            var f3 = () => {
+                "use strict";
+            }
+        }
+        (() => {
+            "use strict";
+        })();
+    }
+    expect: {
+        var f0 = () => 0;
+        var f1 = () => {};
+        var f2 = () => {
+            "use strict";
+            var f3 = () => {};
+        };
+    }
+    node_version: ">=6"
+}
+
+drop_lone_use_strict_arrows_2: {
+    options = {
+        dead_code: true,
+        passes: 2,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        let f0 = () => 0;
+        let f1 = () => {
+            "use strict";
+        }
+        let f2 = () => {
+            "use strict";
+            let f3 = () => {
+                "use strict";
+            }
+        }
+        (() => {
+            "use strict";
+            return undefined;
+        })();
+    }
+    expect: {
+        let f0 = () => 0;
+        let f1 = () => {};
+        let f2 = () => {};
+    }
+    node_version: ">=6"
+}

--- a/test/compress/hoist_props.js
+++ b/test/compress/hoist_props.js
@@ -949,3 +949,32 @@ issue_3021: {
     }
     expect_stdout: "2 2"
 }
+
+issue_3046: {
+    options = {
+        hoist_props: true,
+        reduce_vars: true,
+    }
+    input: {
+        console.log(function(a) {
+            do {
+                var b = {
+                    c: a++
+                };
+            } while (b.c && a);
+            return a;
+        }(0));
+    }
+    expect: {
+        // NOTE: differs from uglify-js, but produces correct result
+        console.log(function(a) {
+            do {
+                var b = {
+                    c: a++
+                };
+            } while (b.c && a);
+            return a;
+        }(0));
+    }
+    expect_stdout: "1"
+}

--- a/test/compress/pure_funcs.js
+++ b/test/compress/pure_funcs.js
@@ -535,3 +535,110 @@ issue_2705_6: {
         "/* */new(/* */a()||b())(c(),d());",
     ]
 }
+
+issue_3065_1: {
+    options = {
+        inline: true,
+        pure_funcs: [ "pureFunc" ],
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function modifyWrapper(a, f, wrapper) {
+            wrapper.a = a;
+            wrapper.f = f;
+            return wrapper;
+        }
+        function pureFunc(fun) {
+            return modifyWrapper(1, fun, function(a) {
+                return fun(a);
+            });
+        }
+        var unused = pureFunc(function(x) {
+            return x;
+        });
+    }
+    expect: {}
+}
+
+issue_3065_2: {
+    rename = true
+    options = {
+        inline: true,
+        pure_funcs: [ "pureFunc" ],
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    mangle = {
+        reserved: [ "pureFunc" ],
+        toplevel: true,
+    }
+    input: {
+        function modifyWrapper(a, f, wrapper) {
+            wrapper.a = a;
+            wrapper.f = f;
+            return wrapper;
+        }
+        function pureFunc(fun) {
+            return modifyWrapper(1, fun, function(a) {
+                return fun(a);
+            });
+        }
+        var unused = pureFunc(function(x) {
+            return x;
+        });
+    }
+    expect: {}
+}
+
+issue_3065_3: {
+    options = {
+        pure_funcs: [ "debug" ],
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function debug(msg) {
+            console.log(msg);
+        }
+        debug(function() {
+            console.log("PASS");
+            return "FAIL";
+        }());
+    }
+    expect: {
+        (function() {
+            console.log("PASS");
+        })();
+    }
+}
+
+issue_3065_4: {
+    options = {
+        pure_funcs: [ "debug" ],
+        reduce_vars: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var debug = function(msg) {
+            console.log(msg);
+        };
+        debug(function() {
+            console.log("PASS");
+            return "FAIL";
+        }());
+    }
+    expect: {
+        (function() {
+            console.log("PASS");
+        })();
+    }
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -6331,3 +6331,59 @@ issue_2992: {
     }
     expect_stdout: "PASS"
 }
+
+issue_3068_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        (function() {
+            do {
+                continue;
+                var b = "defined";
+            } while (b && b.c);
+        })();
+    }
+    expect: {
+        (function() {
+            do {
+                continue;
+                var b = "defined";
+            } while (b && b.c);
+        })();
+    }
+    expect_stdout: true
+}
+
+issue_3068_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        (function() {
+            do {
+                try {
+                    while ("" == typeof a);
+                } finally {
+                    continue;
+                }
+                var b = "defined";
+            } while (b && b.c);
+        })();
+    }
+    expect: {
+        (function() {
+            do {
+                try {
+                    while ("" == typeof a);
+                } finally {
+                    continue;
+                }
+                var b = "defined";
+            } while (b && b.c);
+        })();
+    }
+    expect_stdout: true
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -6301,3 +6301,33 @@ issue_3125: {
     }
     expect_stdout: "7"
 }
+
+issue_2992: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var c = "PASS";
+        (function f(b) {
+            switch (0) {
+            case 0:
+            case b = 1:
+                b && (c = "FAIL");
+            }
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = "PASS";
+        (function f(b) {
+            switch (0) {
+            case 0:
+            case b = 1:
+                b && (c = "FAIL");
+            }
+        })();
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/input/defaults/input.js
+++ b/test/input/defaults/input.js
@@ -1,0 +1,3 @@
+if (true) {
+    console.log(1 + 2);
+}

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -752,4 +752,12 @@ describe("bin/uglifyjs", function () {
             done();
         });
     });
+    it("Should work with -c defaults=false,conditionals", function(done) {
+        var command = uglifyjscmd + " test/input/defaults/input.js -c defaults=false,conditionals";
+        exec(command, function(err, stdout, stderr) {
+            if (err) throw err;
+            assert.strictEqual(stdout, 'true&&console.log(1+2);\n');
+            done();
+        });
+    });
 });

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -419,4 +419,25 @@ describe("minify", function() {
             }
         });
     });
+
+    it("should work with compress defaults disabled", function() {
+        var code = 'if (true) { console.log(1 + 2); }';
+        var options = {
+            compress: {
+                defaults: false,
+            }
+        };
+        assert.strictEqual(Uglify.minify(code, options).code, 'if(true)console.log(1+2);');
+    });
+
+    it("should work with compress defaults disabled and evaluate enabled", function() {
+        var code = 'if (true) { console.log(1 + 2); }';
+        var options = {
+            compress: {
+                defaults: false,
+                evaluate: true,
+            }
+        };
+        assert.strictEqual(Uglify.minify(code, options).code, 'if(true)console.log(3);');
+    });
 });

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -148,7 +148,7 @@ function run_compress_tests() {
                 input.figure_out_scope(test.mangle);
                 input.expand_names(test.mangle);
             }
-            var cmp = new U.Compressor(options, true);
+            var cmp = new U.Compressor(options, options.defaults === undefined ? true : !options.defaults);
             var output = cmp.compress(input);
             output.figure_out_scope(test.mangle);
             if (test.mangle) {


### PR DESCRIPTION
Note: generated code may be different from `uglify-js` as most optimization and feature PRs were not merged.